### PR TITLE
Fix/caching delete

### DIFF
--- a/src/breakfast.py
+++ b/src/breakfast.py
@@ -275,7 +275,8 @@ def calc_sparse_matrix(meta, args):
                     neigh_set = [e for e in neigh_set if e not in set(delSeqs_grouped_idx)]
                     # change remaining indices
                     neigh_set_updatedidx = [indices_dict[ind] for ind in neigh_set]
-                    neigh_cached_updated.append(np.array(neigh_set_updatedidx))
+                    if neigh_set_updatedidx:
+                        neigh_cached_updated.append(np.array(neigh_set_updatedidx))
                 neigh = neigh_cached_updated + neigh_new
             else:          
                 neigh = neigh_cached + neigh_new 


### PR DESCRIPTION
This was caused by deleted sequences ending up with an empty list of neighbours. Usually we don't have that problem because each sequence has itself as a neighbour, but after deleting a sequence the list ends up empty which causes problems with the graph building code.

Tested the change with a single deleted seq at the end of the input file, as well as a deleted seq in the middle of the file. Output is identical to the uncached output.