### PR TITLE
Rewrite caching to handle deletions, modifications, reordering, etc

### DIFF
--- a/src/breakfast.py
+++ b/src/breakfast.py
@@ -175,8 +175,8 @@ def calc_sparse_matrix(meta, args):
         def ungroup_df(df):
             df_ungrouped = pd.DataFrame(
                 {
-                    id: np.concatenate(df["id"].values),
-                    feature: np.repeat(df["feature"].values, df["id"].str.len()),
+                    "id": np.concatenate(df["id"].values),
+                    "feature": np.repeat(df["feature"].values, df["id"].str.len()),
                 }
             )
             return df_ungrouped
@@ -214,7 +214,7 @@ def calc_sparse_matrix(meta, args):
         new_seqs_grouped_idx = []
         del_seqs_grouped_idx = []
         # go trough all current ID sets
-        for grouped_seqs_idx, grouped_seqs in enumerate(current_ID):
+        for grouped_seqs_idx, grouped_seqs in enumerate(current_id):
             counter_new_seq = 0
             # are all set members new?
             for seq in grouped_seqs:
@@ -237,7 +237,7 @@ def calc_sparse_matrix(meta, args):
             # Example 2
             # same as above but deleted sequence: (ID3)
             # This would affect the indices and results which come after ID3
-            for grouped_seqs_idx, grouped_seqs in enumerate(cached_ID):
+            for grouped_seqs_idx, grouped_seqs in enumerate(cached_id):
                 counter_del_seq = 0
                 for seq in grouped_seqs:
                     if seq in del_seqs:

--- a/src/breakfast.py
+++ b/src/breakfast.py
@@ -1,27 +1,21 @@
 #!/usr/bin/env python
+
 VERSION = "0.3.0"
 
 import argparse
-import sys
-from itertools import chain
-from scipy.sparse import csr_matrix
-from sklearn.metrics import pairwise_distances_chunked
-from sklearn.metrics import pairwise_distances
-import pandas as pd
-import numpy as np
+import gzip
 import os
 import re
+import sys
+from itertools import chain
+
 import _pickle as cPickle
-
-# import hashlib
-import gzip
-
-
 import networkx
+import numpy as np
+import pandas as pd
 from networkx.algorithms.components.connected import connected_components
-
-# import time
-# start_time = time.time()
+from scipy.sparse import csr_matrix
+from sklearn.metrics import pairwise_distances_chunked
 
 
 # Merge connected components

--- a/src/breakfast.py
+++ b/src/breakfast.py
@@ -17,6 +17,8 @@ from networkx.algorithms.components.connected import connected_components
 from scipy.sparse import csr_matrix
 from sklearn.metrics import pairwise_distances_chunked
 
+import cache as ca
+
 
 # Merge connected components
 def _to_graph(l):
@@ -136,64 +138,10 @@ def calc_sparse_matrix(meta, args):
             print("Import from pickle file")
             cache = cPickle.load(f)
 
-        max_dist_cached = cache["max_dist"]
+        ca.validate(cache, args, VERSION)
 
-        if args.max_dist != max_dist_cached:
-            print(
-                f"WARNING: Cached results were created using a differnt max-dist paramter"
-            )
-            print(
-                f"Current max-dist parameter: {args.max_dist} \n Cached max-dist parameter: {max_dist_cached}"
-            )
-            raise UnboundLocalError()
-
-        version_cached = cache["version"]
-        if version_cached != VERSION:
-            print(
-                f"WARNING: Cached results were created using breakfast version {version_cached}"
-            )
-
-        # compare cached IDs and current IDs to check if sequences have been deleted
-        meta_cached = cache["meta"]
-        cached_seqs = meta_cached["feature"]
-        cached_id = meta_cached["id"]
-        current_id = meta["id"].tolist()
-
-        # flatten list of IDs to compare cached and current IDs
-        # since we summarized IDs with identical sequences to sets
-        # e.g. [(ID1, ID2), (ID3)] -> {ID1, ID2, ID3}
-        flat_cached_id = set(item for sublist in cached_id for item in sublist)
-        flat_current_id = set(item for sublist in current_id for item in sublist)
-
-        # get all IDs which are part of cached ID but not anymore of current ID
-        del_seqs = list(flat_cached_id.difference(flat_current_id))
-        new_seqs = list(flat_current_id.difference(flat_cached_id))
-        common_seqs = list(flat_cached_id.intersection(flat_current_id))
-
-        # Undo the grouping/deduplication of sequences so we can work with
-        # individual sequence ids
-        def ungroup_df(df):
-            df_ungrouped = pd.DataFrame(
-                {
-                    "id": np.concatenate(df["id"].values),
-                    "feature": np.repeat(df["feature"].values, df["id"].str.len()),
-                }
-            )
-            return df_ungrouped
-
-        meta_cached_ungrouped = ungroup_df(meta_cached).set_index("id")
-        meta_new_ungrouped = ungroup_df(meta).set_index("id")
-
-        meta_merged = meta_cached_ungrouped.join(
-            meta_new_ungrouped, how="inner", lsuffix="_cached", rsuffix="_new"
-        )
-        meta_merged["modified"] = (
-            meta_merged["feature_cached"] != meta_merged["feature_new"]
-        )
-        mod_seqs = meta_merged[meta_merged["modified"]].index.tolist()
-
-        print(f"{len(mod_seqs)} modified sequence(s)")
-        print(f"The following sequences were modified {mod_seqs}")
+        del_seqs, new_seqs, common_seqs = ca.find_deleted(cache, meta)
+        mod_seqs = ca.find_modified(cache, meta)
 
         # Update the deleted seqs list with the sequences that were
         # modified, and also add them to the "new_seqs" list so that they
@@ -213,6 +161,7 @@ def calc_sparse_matrix(meta, args):
         new_seqs_grouped = []
         new_seqs_grouped_idx = []
         del_seqs_grouped_idx = []
+        current_id = meta["id"].tolist()
         # go trough all current ID sets
         for grouped_seqs_idx, grouped_seqs in enumerate(current_id):
             counter_new_seq = 0
@@ -225,6 +174,8 @@ def calc_sparse_matrix(meta, args):
                 new_seqs_grouped.append(grouped_seqs)
                 new_seqs_grouped_idx.append(grouped_seqs_idx)
 
+        meta_cached = cache["meta"]
+        cached_id = meta_cached["id"]
         if (len(del_seqs)) > 0:
             print(f"{len(del_seqs)} deleted sequence(s)")
             print(f"The following sequences got deleted {del_seqs}")

--- a/src/breakfast.py
+++ b/src/breakfast.py
@@ -103,7 +103,9 @@ def construct_sub_mat(meta, args):
                 d = [subt]
         for term in d:
             if args.var_type == "dna":
-                if term.startswith("del"):
+                if len(term) == 0:
+                    continue
+                elif term.startswith("del"):
                     if args.skip_del:
                         continue
                     pos = int(term.split(":")[1])

--- a/src/cache.py
+++ b/src/cache.py
@@ -36,7 +36,8 @@ def update_neighbours(neigh, fmap):
 
     neigh_updated = []
     for i, nlist in enumerate(neigh):
-        nlist_updated = [c2n[item] for item in nlist if not math.isnan(c2n[item])]
+        nlist_updated = [c2n[item] for item in nlist]
+        nlist_updated = [x for x in nlist_updated if x is not None]
         if len(nlist_updated) > 0:
             neigh_updated.append(nlist_updated)
 

--- a/src/cache.py
+++ b/src/cache.py
@@ -1,3 +1,4 @@
+import math
 import numpy as np
 import pandas as pd
 
@@ -19,17 +20,23 @@ def validate(cache, args, version):
             f"WARNING: Cached results were created using breakfast version {version_cached}"
         )
 
+
 def update_neighbours(neigh, fmap):
-    """Update cached neighrours list to index into new data properly
+    """Update cached neighbours list to index into new data properly
 
     This includes deleting elements that have been deleted from the new data
     set, and also updating the indexes in the neigh list to properly point to
     the right data in the new data set.
     """
-    c2n = fmap.set_index("idx_cache")
+    # Create a list that can do lookups in O(1)
+    max_idx = int(max(fmap["idx_cache"].dropna()))
+    c2n = [None] * (max_idx + 1)
+    for idx, row in fmap.dropna().iterrows():
+        c2n[int(row["idx_cache"])] = int(row["idx_new"])
+
     neigh_updated = []
-    for nlist in neigh:
-        nlist_updated = c2n.loc[nlist, "idx_new"].dropna().astype(int).tolist()
+    for i, nlist in enumerate(neigh):
+        nlist_updated = [c2n[item] for item in nlist if not math.isnan(c2n[item])]
         if len(nlist_updated) > 0:
             neigh_updated.append(nlist_updated)
 

--- a/src/cache.py
+++ b/src/cache.py
@@ -29,7 +29,7 @@ def update_neighbours(neigh, fmap):
     c2n = fmap.set_index("idx_cache")
     neigh_updated = []
     for nlist in neigh:
-        nlist_updated = c2n.loc[nlist, "idx_new"].dropna().tolist()
+        nlist_updated = c2n.loc[nlist, "idx_new"].dropna().astype(int).tolist()
         if len(nlist_updated) > 0:
             neigh_updated.append(nlist_updated)
 

--- a/src/cache.py
+++ b/src/cache.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pandas as pd
+
+def validate(cache, args, version):
+    max_dist_cached = cache["max_dist"]
+
+    if args.max_dist != max_dist_cached:
+        print(
+            f"WARNING: Cached results were created using a differnt max-dist paramter"
+        )
+        print(
+            f"Current max-dist parameter: {args.max_dist} \n Cached max-dist parameter: {max_dist_cached}"
+        )
+        raise UnboundLocalError()
+
+    version_cached = cache["version"]
+    if version_cached != version:
+        print(
+            f"WARNING: Cached results were created using breakfast version {version_cached}"
+        )
+
+def find_deleted(cache, meta):
+    # compare cached IDs and current IDs to check if sequences have been deleted
+    meta_cached = cache["meta"]
+    cached_seqs = meta_cached["feature"]
+    cached_id = meta_cached["id"]
+    current_id = meta["id"].tolist()
+
+    # flatten list of IDs to compare cached and current IDs
+    # since we summarized IDs with identical sequences to sets
+    # e.g. [(ID1, ID2), (ID3)] -> {ID1, ID2, ID3}
+    flat_cached_id = set(item for sublist in cached_id for item in sublist)
+    flat_current_id = set(item for sublist in current_id for item in sublist)
+
+    # get all IDs which are part of cached ID but not anymore of current ID
+    del_seqs = list(flat_cached_id.difference(flat_current_id))
+    new_seqs = list(flat_current_id.difference(flat_cached_id))
+    common_seqs = list(flat_cached_id.intersection(flat_current_id))
+
+    return del_seqs, new_seqs, common_seqs
+
+def find_modified(cache, meta):
+    # Undo the grouping/deduplication of sequences so we can work with
+    # individual sequence ids
+    def ungroup_df(df):
+        df_ungrouped = pd.DataFrame(
+            {
+                "id": np.concatenate(df["id"].values),
+                "feature": np.repeat(df["feature"].values, df["id"].str.len()),
+            }
+        )
+        return df_ungrouped
+
+    meta_cached = cache["meta"]
+    meta_cached_ungrouped = ungroup_df(meta_cached).set_index("id")
+    meta_new_ungrouped = ungroup_df(meta).set_index("id")
+
+    meta_merged = meta_cached_ungrouped.join(
+        meta_new_ungrouped, how="inner", lsuffix="_cached", rsuffix="_new"
+    )
+    meta_merged["modified"] = (
+        meta_merged["feature_cached"] != meta_merged["feature_new"]
+    )
+    mod_seqs = meta_merged[meta_merged["modified"]].index.tolist()
+
+    print(f"{len(mod_seqs)} modified sequence(s)")
+    print(f"The following sequences were modified {mod_seqs}")
+
+    return mod_seqs


### PR DESCRIPTION
Significantly change cached data handling to easily handle every situation we are likely to have. Ignore IDs, and only focus on the content of the mutation strings themselves. Use the mutations to map between cached indexes and new data indexes, so we can rewrite the neighbour object (removing deleted/modified sequences, and reordering as necessary). This neighbour object update is currently slow, but I have some ideas for greatly reducing the amount of work that needs to be done.

Tested in 3 steps:
1) add 50k sequences: runtime 4:30.56 minutes
2) add 55k sequences (the previous 50k + 5k new seqs), using cache from 1): runtime 2:51.71 minutes
3) add 55k sequences, no cache: runtime 5:23.82 minutes

Output clusters are identical, but the cluster ids differ between runs 2) and 3).