### PR TITLE
Speedup by splitting up sparse matrix into batches

### DIFF
--- a/src/breakfast/breakfast.py
+++ b/src/breakfast/breakfast.py
@@ -166,8 +166,7 @@ def construct_sub_mat(features, feature_sep):
 
 
 def filter_where(arr, k_min, k_max):
-    arr = arr[np.where(arr >= k_min)]
-    arr = arr[np.where(arr <= k_max)]
+    arr = arr[np.where(arr >= k_min) and np.where(arr <= k_max)]
     return arr
 
 
@@ -185,9 +184,9 @@ def sparse_matrix_batch(
     if select_ind is None:
         sub_mat_only_new_seqs = sub_mat
     else:
-        first_idx = meta_subset.index[0]
-        last_idx = meta_subset.index[-1]
-        select_ind_subset = filter_where(select_ind, first_idx, last_idx)
+        select_ind_subset = filter_where(
+            select_ind, meta_subset.index[0], meta_subset.index[-1]
+        )
         meta_subset_reidx = meta_subset.reset_index()
         if len(select_ind_subset) > 0:
             select_ind_subset = meta_subset_reidx[

--- a/src/breakfast/breakfast.py
+++ b/src/breakfast/breakfast.py
@@ -47,8 +47,7 @@ def write_output(meta_nodups, meta_original, outdir):
     meta_out = meta_out.reindex(index=meta_original["id"])
     meta_out = meta_out.reset_index()
 
-    # Assign new cluster IDs according
-
+    # Assign new cluster IDs according to order of input file
     keys = list(dict.fromkeys(meta_out["cluster_id"].tolist()))
     keys = [x for x in keys if not pd.isna(x)]
     dict_id = {}
@@ -56,9 +55,8 @@ def write_output(meta_nodups, meta_original, outdir):
     for i in range(len(keys)):
         new_cluster_id += 1
         dict_id[keys[i]] = new_cluster_id
-
-    # create dictonary
-    meta_out = meta_out.replace({"cluster_id": dict_id})
+    replacer = dict_id.get
+    meta_out["cluster_id"] = [replacer(n, n) for n in meta_out["cluster_id"].tolist()]
 
     assert meta_out.shape[0] == meta_original.shape[0]
 

--- a/src/breakfast/breakfast.py
+++ b/src/breakfast/breakfast.py
@@ -41,10 +41,25 @@ def write_output(meta_nodups, meta_original, outdir):
     meta_out = pd.DataFrame()
     meta_out["id"] = meta_accession
     meta_out["cluster_id"] = meta_clusterid
+
     # Sort according to input file
     meta_out = meta_out.set_index("id")
     meta_out = meta_out.reindex(index=meta_original["id"])
     meta_out = meta_out.reset_index()
+
+    # Assign new cluster IDs according
+
+    keys = list(dict.fromkeys(meta_out["cluster_id"].tolist()))
+    keys = [x for x in keys if not pd.isna(x)]
+    dict_id = {}
+    new_cluster_id = 0
+    for i in range(len(keys)):
+        new_cluster_id += 1
+        dict_id[keys[i]] = new_cluster_id
+
+    # create dictonary
+    meta_out = meta_out.replace({"cluster_id": dict_id})
+
     assert meta_out.shape[0] == meta_original.shape[0]
 
     if not os.path.exists(outdir):
@@ -204,10 +219,7 @@ def sparse_matrix_batch(
     )
 
     neigh = list(chain.from_iterable(gen))
-    if select_ind is None:
-        neigh = [x + meta_subset.index[0] for x in neigh]
-    else:
-        neigh = [x + meta_subset.index[0] for x in neigh]
+    neigh = [x + meta_subset.index[0] for x in neigh]
     return neigh
 
 

--- a/src/breakfast/console.py
+++ b/src/breakfast/console.py
@@ -80,7 +80,6 @@ def main(
         trim_end,
         reference_length,
     )
-    
     meta_nodups = breakfast.collapse_duplicates(meta)
 
     meta_clustered = breakfast.cluster(

--- a/src/breakfast/console.py
+++ b/src/breakfast/console.py
@@ -70,7 +70,7 @@ def main(
 
     meta = breakfast.read_input(input_file, sep, id_col, clust_col)
 
-    meta["feature"] = breakfast.filter_features(
+    meta["feature"], meta["mutation length"] = breakfast.filter_features(
         meta["feature"],
         sep2,
         var_type,
@@ -80,7 +80,7 @@ def main(
         trim_end,
         reference_length,
     )
-
+    
     meta_nodups = breakfast.collapse_duplicates(meta)
 
     meta_clustered = breakfast.cluster(

--- a/tests/expected_clusters_caching06_dist1.tsv
+++ b/tests/expected_clusters_caching06_dist1.tsv
@@ -3,8 +3,8 @@ example1-1	1
 example1-2	1
 example1-3	1
 example2-1	1
-example2-2	3
-exampledel1	2
-exampledel2	2
-example3-1	3
-example3-2	3
+example2-2	2
+exampledel1	3
+exampledel2	3
+example3-1	2
+example3-2	2


### PR DESCRIPTION
Decrease runtime of breakfast by splitting up the constructed sparse matrix of all sequences into batches of smaller matrices and compute the pairwise distance of these smaller matrices. The speedup is gained by skipping distance calculations between sequences of different mutation lengths. If f.e. sequence A has a mutation length of 14, sequence B has a mutation length of 16 and we cluster with max-dist = 1, we do not need to compare sequence A and B since we know that A has at least an edit distance of 2 compared to B. Hence, we group the sequences according to the mutation length and calculate smaller sparse matrices for each mutation length group. That means that f.e. sequence A will only be compared with sequences of a mutation length of 13, 14, and 15. This is done straightforward by looping the sub_mat construction and calling pairwise_distances_chunked for each batch. The speedup is compatible with the caching process, sparse_matrix_batch function just checks if cached sequences are present in the current mutation length batch.

Runtime 100K sequences: 0:23.62 minutes
Runtime 150K sequences: 0:36.97 minutes
Runtime 200K sequences: 0:54.74 minutes
Runtime 200K sequences (with 150K cached sequences): 0:46.36 minutes