### PR TITLE
Fix for Commented-out code

### DIFF
--- a/tests/test_filtering.py
+++ b/tests/test_filtering.py
@@ -97,10 +97,3 @@ def test_sparse_feature_matrix_ignores_empty_features():
     assert matrix.shape == (2, 1)
     assert matrix[0].count_nonzero() == 0
     assert matrix[1].count_nonzero() == 1
-
-
-# def test_filter_invalid_dna_sub():
-#     features = ["C241t"]
-#     expected = ["C241T"]
-#     filtered = breakfast.filter_features(features, ",", "covsonar_dna", True, False, 0, 0, 1000)
-#     assert filtered[0] == expected[0]


### PR DESCRIPTION
To fix this without changing functionality, remove the commented-out code block at the end of `tests/test_filtering.py` (lines 102–106 in the snippet). This resolves the CodeQL warning while keeping runtime behavior identical, since commented code is not executed anyway.

Best single fix:
- Edit `tests/test_filtering.py`
- Delete the commented-out test block beginning with `# def test_filter_invalid_dna_sub():` and its commented body lines.

No imports, methods, or definitions are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._