### PR TITLE
Change to using trusted publishing for (test) PyPI uploads

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: pypi
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v6
     - uses: astral-sh/setup-uv@v8.2.0
@@ -17,6 +22,3 @@ jobs:
     - run: uv run pytest --cov
     - run: uv build
     - run: uv publish
-      env:
-        UV_PUBLISH_USERNAME: __token__
-        UV_PUBLISH_PASSWORD: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/test-pypi.yml
+++ b/.github/workflows/test-pypi.yml
@@ -6,6 +6,11 @@ on:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment:
+      name: testpypi
+    permissions:
+      id-token: write
+      contents: read
     steps:
     - uses: actions/checkout@v6
     - uses: astral-sh/setup-uv@v8.2.0
@@ -19,6 +24,3 @@ jobs:
     - run: version=$(uv version --short) && uv version "$version.dev.$(date +%s)"
     - run: uv build
     - run: uv publish --publish-url https://test.pypi.org/legacy/
-      env:
-        UV_PUBLISH_USERNAME: __token__
-        UV_PUBLISH_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}


### PR DESCRIPTION
This is the preferred way of publishing apparently. See https://docs.astral.sh/uv/guides/integration/github/#private-repos

Not tested yet. Will try test PyPI by pushing to dev.
